### PR TITLE
Added link to CCG2 form for 2016-17

### DIFF
--- a/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_ccg_expenses.govspeak.erb
+++ b/lib/smart_answer_flows/student-finance-forms/outcomes/outcome_ccg_expenses.govspeak.erb
@@ -7,13 +7,13 @@
 
   At the end of each term confirm your actual childcare costs. Use the CCG2 form for the academic year the costs relate to.
 
-  Academic Year | Form
+  Academic year | Form
   - | -
-  2016 to 2017 | Form available September 2016
-  2015 to 2016 | [CCG2 - cost confirmation form (PDF, 295KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_ccg2_form_1516_d.pdf)
-  2014 to 2015 | [CCG2 - cost confirmation form (PDF, 210KB)](http://media.slc.co.uk/sfe/1415/ft/sfe_ccg2_1415_d.pdf)
-  2013 to 2014 | [CCG2 – cost confirmation form (PDF, 201KB)](http://media.slc.co.uk/sfe/1314/ft/sfe_ccg2_1314_d.pdf)
-
+  2016 to 2017 | [CCG2: Childcare Costs Confirmation Form 2016 to 2017 (PDF, 202KB)](http://media.slc.co.uk/sfe/1617/ft/sfe_ccg2_form_1617_d.pdf)
+  2015 to 2016 | [CCG2: Childcare Costs Confirmation Form 2015 to 2016 (PDF, 295KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_ccg2_form_1516_d.pdf)
+  2014 to 2015 | [CCG2: Childcare Costs Confirmation Form 2014 to 2015 (PDF, 252KB)](http://media.slc.co.uk/sfe/1415/ft/sfe_ccg2_1415_d.pdf)   
+  2013 to 2014 | [CCG2: Childcare Costs Confirmation Form 2013 to 2014 (PDF, 206KB)](http://media.slc.co.uk/sfe/1314/ft/sfe_ccg2_1314_d.pdf)   
+  
   ##Where to send your form(s)
 
   $A


### PR DESCRIPTION
*\* DO NOT PUT LIVE UNTIL 1 SEP 2016
*\* PUT LIVE WITH https://publisher.publishing.service.gov.uk/editions/57ad849ae5274a65a4593cc6

https://govuk.zendesk.com/agent/tickets/1391059
https://trello.com/c/SeyotVSa/242-update-to-form-finder-add-ccg2-form

CHANGED
  Academic Year | Form
- | -
  2016 to 2017 | Form available September 2016
  2015 to 2016 | [CCG2 - cost confirmation form (PDF, 295KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_ccg2_form_1516_d.pdf)
  2014 to 2015 | [CCG2 - cost confirmation form (PDF, 210KB)](http://media.slc.co.uk/sfe/1415/ft/sfe_ccg2_1415_d.pdf)
  2013 to 2014 | [CCG2 – cost confirmation form (PDF, 201KB)](http://media.slc.co.uk/sfe/1314/ft/sfe_ccg2_1314_d.pdf)

TO
  Academic year | Form
- | -
  2016 to 2017 | [CCG2: Childcare Costs Confirmation Form 2016 to 2017 (PDF, 202KB)](http://media.slc.co.uk/sfe/1617/ft/sfe_ccg2_form_1617_d.pdf)
  2015 to 2016 | [CCG2: Childcare Costs Confirmation Form 2015 to 2016 (PDF, 295KB)](http://media.slc.co.uk/sfe/1516/ft/sfe_ccg2_form_1516_d.pdf)
  2014 to 2015 | [CCG2: Childcare Costs Confirmation Form 2014 to 2015 (PDF, 252KB)](http://media.slc.co.uk/sfe/1415/ft/sfe_ccg2_1415_d.pdf)  
  2013 to 2014 | [CCG2: Childcare Costs Confirmation Form 2013 to 2014 (PDF, 206KB)](http://media.slc.co.uk/sfe/1314/ft/sfe_ccg2_1314_d.pdf)  

REASON
- 2016-17 CCG2 form is now available
- Fixed first heading column and rest of table to match style on https://www.gov.uk/childcare-grant/how-to-claim
- Fixed file sizes
